### PR TITLE
Fix typo in installation dir for header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(${lib_name} PRIVATE
 )
 
 set_target_properties(${lib_name} PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-set_target_properties(${lib_name} PROPERTIES PUBLIC_HEADER ${INCDIR}/ozimmu/${library}.hpp)
+set_target_properties(${lib_name} PROPERTIES PUBLIC_HEADER ${INCDIR}/ozimmu/${lib_name}.hpp)
 target_compile_options(${lib_name} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ptxas-options=-v>)
 
 ##########################################################################


### PR DESCRIPTION
With this change, the header file installs in the `include` directory.